### PR TITLE
Fixed this error when ''jekyll build --trace"

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -1,3 +1,5 @@
+require "zlib"
+
 module Jekyll
   class Avatar < Liquid::Tag
     SERVERS      = 4


### PR DESCRIPTION
Fixed this error when ''jekyll build --trace"

Liquid Exception: uninitialized constant Jekyll::Avatar::Zlib in _layouts/news_item.html
/usr/local/lib/ruby/gems/2.3.0/gems/jekyll-avatar-0.4.0/lib/jekyll-avatar.rb:52:in `server_number': uninitialized constant Jekyll::Avatar::Zlib (NameError)