### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,7 @@ Metrics/LineLength:
 
 Metrics/BlockLength:
   Enabled: false
+
+AllCops:
+  Exclude:
+    - vendor/*/**

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ Style/FileName:
 Metrics/LineLength:
   Exclude:
     - spec/*/**
+
+Metrics/BlockLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,4 +13,4 @@ Metrics/BlockLength:
 
 AllCops:
   Exclude:
-    - vendor/*/**
+    - vendor/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-source 'https://rubygems.org'
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-avatar.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -72,3 +72,12 @@ Or, if the variable is someplace a bit more complex, like a loop:
   {% avatar user=employee %}
 {% endfor %}
 ```
+
+### Using with GitHub Enterprise
+
+To use Jekyll Avatars with GitHub Enterprise, you must set the `PAGES_AVATARS_URL` environmental variable.
+
+This should be the full URL to the avatars subdomain or subpath. For example:
+
+* With subdomain isolation: `PAGES_AVATARS_URL="https://avatars.github.example.com"`
+* Without subdomain isolation: `PAGES_AVATARS_URL="https://github.example.com/avatars"` 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task :default => :spec

--- a/jekyll-avatar.gemspec
+++ b/jekyll-avatar.gemspec
@@ -1,28 +1,29 @@
 # coding: utf-8
 # frozen_string_literal: true
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-avatar/version'
+require "jekyll-avatar/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'jekyll-avatar'
+  spec.name          = "jekyll-avatar"
   spec.version       = Jekyll::Avatar::VERSION
-  spec.authors       = ['Ben Balter']
-  spec.email         = ['ben.balter@github.com']
+  spec.authors       = ["Ben Balter"]
+  spec.email         = ["ben.balter@github.com"]
 
-  spec.summary       = 'A Jekyll plugin for rendering GitHub avatars'
-  spec.homepage      = 'https://github.com/benbalter/jekyll-avatar'
-  spec.license       = 'MIT'
+  spec.summary       = "A Jekyll plugin for rendering GitHub avatars"
+  spec.homepage      = "https://github.com/benbalter/jekyll-avatar"
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |file|
-    file.match(%r{^(test|spec|features)/})
+    file.match(%r!^(test|spec|features)/!)
   end
 
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jekyll', '~> 3.0'
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop'
+  spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop"
 end

--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "zlib"
 
 module Jekyll
@@ -31,7 +32,7 @@ module Jekyll
         :srcset               => srcset,
         :width                => size,
         :height               => size,
-        "data-proofer-ignore" => true
+        "data-proofer-ignore" => true,
       }
     end
 
@@ -58,11 +59,17 @@ module Jekyll
     end
 
     def host
-      "avatars#{server_number}.githubusercontent.com"
+      if ENV["PAGES_AVATARS_URL"].to_s.empty?
+        "https://avatars#{server_number}.githubusercontent.com"
+      else
+        ENV["PAGES_AVATARS_URL"]
+      end
     end
 
     def url(scale = 1)
-      "https://#{host}/#{path(scale)}"
+      uri = Addressable::URI.parse host
+      uri.path << "/" unless uri.path.end_with?("/")
+      uri.join path(scale)
     end
 
     def srcset

--- a/lib/jekyll-avatar/version.rb
+++ b/lib/jekyll-avatar/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Liquid; class Tag; end; end
 module Jekyll
   class Avatar < Liquid::Tag

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require "jekyll"
@@ -44,4 +45,12 @@ end
 def fixture(name)
   path = File.expand_path "./fixtures/#{name}.json", File.dirname(__FILE__)
   File.open(path).read
+end
+
+def with_env(key, value)
+  old_value = ENV[key]
+  ENV[key] = value
+  yield
+ensure
+  ENV[key] = old_value
 end


### PR DESCRIPTION
Fixes https://github.com/benbalter/jekyll-avatar/issues/12. 

If the User (or the build environment) specifies a `PAGES_AVATARS_URL` prefer that to the GitHub.com avatars URL.

/cc @jimkohl, @parkr