### PR TITLE
support lazy loading of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Or, if the variable is someplace a bit more complex, like a loop:
 {% endfor %}
 ```
 
+### Lazy loading images
+
+For pages showing a large number of avatars, you may want to load the images lazily.
+
+```liquid
+{% avatar hubot lazy=true %}
+```
+
+This will set the `data-src` and `data-srcset` attributes on the `<img>` tag, which is compatible with many lazy load JavaScript plugins, such as:
+
+* https://www.andreaverlicchi.eu/lazyload/
+* https://appelsiini.net/projects/lazyload/
+
 ### Using with GitHub Enterprise
 
 To use Jekyll Avatars with GitHub Enterprise, you must set the `PAGES_AVATARS_URL` environmental variable.
@@ -80,4 +93,4 @@ To use Jekyll Avatars with GitHub Enterprise, you must set the `PAGES_AVATARS_UR
 This should be the full URL to the avatars subdomain or subpath. For example:
 
 * With subdomain isolation: `PAGES_AVATARS_URL="https://avatars.github.example.com"`
-* Without subdomain isolation: `PAGES_AVATARS_URL="https://github.example.com/avatars"` 
+* Without subdomain isolation: `PAGES_AVATARS_URL="https://github.example.com/avatars"`

--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -25,15 +25,28 @@ module Jekyll
     private
 
     def attributes
-      {
+      result = {
         :class                => classes,
-        :src                  => url,
         :alt                  => username,
-        :srcset               => srcset,
         :width                => size,
         :height               => size,
         "data-proofer-ignore" => true,
       }
+
+      if lazy_load?
+        result[:src] = ''
+        result['data-src'] = url
+        result['data-srcset'] = srcset
+      else
+        result[:src] = url
+        result[:srcset] = srcset
+      end
+
+      result
+    end
+
+    def lazy_load?
+      @text.include?('lazy=true')
     end
 
     def username

--- a/spec/jekyll/avatar_spec.rb
+++ b/spec/jekyll/avatar_spec.rb
@@ -209,4 +209,18 @@ describe Jekyll::Avatar do
       end
     end
   end
+
+  context "lazy loading" do
+    let(:args) { "lazy=true" }
+
+    it "sets the image URL as the data-src" do
+      expect(output).to have_tag 'img', :with => {
+        :src => '',
+        'data-src' => 'https://avatars3.githubusercontent.com/hubot?v=3&s=40',
+        'data-srcset' => 'https://avatars3.githubusercontent.com/hubot?v=3&s=40 1x, https://avatars3.githubusercontent.com/hubot?v=3&s=80 2x, https://avatars3.githubusercontent.com/hubot?v=3&s=120 3x, https://avatars3.githubusercontent.com/hubot?v=3&s=160 4x'
+      }, :without => {
+        :srcset => /.*/
+      }
+    end
+  end
 end


### PR DESCRIPTION
Closes #15. Builds on #17 - [compare](https://github.com/afeld/jekyll-avatar/compare/test-improvements...lazy-load).

This pull request adds an option for supporting lazy loading of images via a JavaScript plugin. Tried these changes out on https://government.github.com/community/ locally with the [vanilla-lazyload](https://www.andreaverlicchi.eu/lazyload/) plugin. Before, on initial page load:

<img alt="screen shot 2018-03-31 at 10 59 03 am" src="https://user-images.githubusercontent.com/86842/38164576-b6cc1876-34d4-11e8-9b2d-9d075e781ecd.png">

After:

<img alt="screen shot 2018-03-31 at 10 58 19 am" src="https://user-images.githubusercontent.com/86842/38164577-bcf0141e-34d4-11e8-8e2e-924602edbd1d.png">

Note that the images won't show up if JavaScript isn't available. It's possible to [get around this with a `<noscript>` fallback](https://www.robinosborne.co.uk/2016/05/16/lazy-loading-images-dont-rely-on-javascript/#a-no-JavaScript), but that would require a more dramatic change to the rendered HTML, which would be a breaking change for users who are expecting the existing structure. Your call!