### PR TITLE
Fix passing username as variable docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ That will output:
 You can also pass the username as a variable, like this:
 
 ```
-{% assign username="hubot" %}
+{% assign user="hubot" %}
 {% avatar {{ username }} %}
 ```
 


### PR DESCRIPTION
This was incorrectly using a `username` variable, when actually it needs to be a `user` variable.