### PR TITLE
Avoid unnecessary allocations for empty strings

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -72,10 +72,10 @@ module Jekyll
     end
 
     def host
-      if ENV["PAGES_AVATARS_URL"].to_s.empty?
-        "https://avatars#{server_number}.githubusercontent.com"
-      else
+      if ENV["PAGES_AVATARS_URL"].is_a?(String) && !ENV["PAGES_AVATARS_URL"].empty?
         ENV["PAGES_AVATARS_URL"]
+      else
+        "https://avatars#{server_number}.githubusercontent.com"
       end
     end
 


### PR DESCRIPTION
## Summary

Instead of coercing the env-var into a String, let us simply check if it is a non-empty String.

## Rationale
*Every call to `#render` **allocates 5 new `""`** just to check if it is empty:*
- `#host` is called *at least* 5 times per call to `#render` via `#url`.
- when `ENV["PAGES_AVATARS_URL"] == nil`, every call to `ENV["PAGES_AVATARS_URL"].to_s` allocates memory for a new `""`.