### PR TITLE
Cache parsed host url to reduce allocations

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -79,8 +79,13 @@ module Jekyll
       end
     end
 
+    def parsed_host
+      @parsed_host ||= {}
+      @parsed_host[host] ||= Addressable::URI.parse(host)
+    end
+
     def url(scale = 1)
-      uri = Addressable::URI.parse host
+      uri = parsed_host
       uri.path << "/" unless uri.path.end_with?("/")
       uri = uri.join path(scale)
       uri.to_s


### PR DESCRIPTION
Closes #35 

## Notes
- Couldn't resort to memoizing `#host` since `#server_number` could change in the context of a Liquid `{% for %} block..
- Caching w.r.t. a `host` value is safer than memoizing to the instance.