### PR TITLE
Parse tag markup once per instance

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -13,11 +13,12 @@ module Jekyll
     def initialize(_tag_name, text, _tokens)
       super
       @text = text
+      @markup = Liquid::Template.parse(text)
     end
 
     def render(context)
       @context = context
-      @text    = Liquid::Template.parse(@text).render(@context)
+      @text    = @markup.render(@context)
       attrs    = attributes.map { |k, v| "#{k}=\"#{v}\"" }.join(" ")
       "<img #{attrs} />"
     end


### PR DESCRIPTION
This change ensures that if there is a single instance of `{% avatar foo %}` which may be *rendered multiple times*, the *tag_markup* or `text` parameter value isn't *parsed by Liquid* for each render.