### PR TITLE
Stringify keys of :attributes hash

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -26,20 +26,20 @@ module Jekyll
 
     def attributes
       result = {
-        :class                => classes,
-        :alt                  => username,
-        :width                => size,
-        :height               => size,
+        "class"               => classes,
+        "alt"                 => username,
+        "width"               => size,
+        "height"              => size,
         "data-proofer-ignore" => true
       }
 
       if lazy_load?
-        result[:src] = ""
+        result["src"] = ""
         result["data-src"] = url
         result["data-srcset"] = srcset
       else
-        result[:src] = url
-        result[:srcset] = srcset
+        result["src"] = url
+        result["srcset"] = srcset
       end
 
       result

--- a/spec/jekyll/avatar_spec.rb
+++ b/spec/jekyll/avatar_spec.rb
@@ -45,13 +45,13 @@ describe Jekyll::Avatar do
   it "outputs the HTML" do
     expect(output).to have_tag("p") do
       with_tag "img", :with => {
-        :alt                  => username,
-        :class                => "avatar avatar-small",
+        "alt"                 => username,
+        "class"               => "avatar avatar-small",
         "data-proofer-ignore" => "true",
-        :height               => height,
-        :src                  => src,
-        :srcset               => srcset,
-        :width                => width
+        "height"              => height,
+        "src"                 => src,
+        "srcset"              => srcset,
+        "width"               => width
       }
     end
   end
@@ -110,12 +110,12 @@ describe Jekyll::Avatar do
     attrs = subject.send(:attributes)
     expect(attrs).to eql({
       "data-proofer-ignore" => true,
-      :class                => "avatar avatar-small",
-      :alt                  => username,
-      :src                  => src,
-      :srcset               => srcset,
-      :width                => width,
-      :height               => height
+      "class"               => "avatar avatar-small",
+      "alt"                 => username,
+      "src"                 => src,
+      "srcset"              => srcset,
+      "width"               => width,
+      "height"              => height
     })
   end
 
@@ -193,7 +193,7 @@ describe Jekyll::Avatar do
     let(:content) { "{% assign user='#{username}' %}{% avatar {{ user }} %}" }
 
     it "parses the variable" do
-      expect(output).to have_tag "img", :with => { :src => src }
+      expect(output).to have_tag "img", :with => { "src" => src }
     end
   end
 
@@ -203,7 +203,7 @@ describe Jekyll::Avatar do
     let(:content) { "{% assign user='hubot2' %}{% avatar user=user %}" }
 
     it "parses the variable" do
-      expect(output).to have_tag "img", :with => { :src => src }
+      expect(output).to have_tag "img", :with => { "src" => src }
     end
   end
 
@@ -213,7 +213,7 @@ describe Jekyll::Avatar do
     let(:content) { "{% avatar user=page.author %}" }
 
     it "parses the variable" do
-      expect(output).to have_tag "img", :with => { :src => src }
+      expect(output).to have_tag "img", :with => { "src" => src }
     end
   end
 
@@ -229,8 +229,8 @@ describe Jekyll::Avatar do
 
     it "renders each avatar" do
       expect(output).to have_tag("p") do
-        with_tag "img", :with => { :alt => "a" }
-        with_tag "img", :with => { :alt => "b" }
+        with_tag "img", :with => { "alt" => "a" }
+        with_tag "img", :with => { "alt" => "b" }
       end
     end
   end
@@ -240,11 +240,11 @@ describe Jekyll::Avatar do
 
     it "sets the image URL as the data-src" do
       expect(output).to have_tag "img", :with => {
-        :src          => "",
+        "src"         => "",
         "data-src"    => src,
         "data-srcset" => srcset
       }, :without => {
-        :srcset => %r!.*!
+        "srcset" => %r!.*!
       }
     end
   end


### PR DESCRIPTION
So as to avoid eventual stringification of symbols in the `:render` method:
https://github.com/benbalter/jekyll-avatar/blob/55edbd23dd8255f570c51a3c2573f2c1aff6d552/lib/jekyll-avatar.rb#L21