### PR TITLE
Compute :srcset with an array of integer strings

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -91,8 +91,11 @@ module Jekyll
       uri.to_s
     end
 
+    SCALES = %w(1 2 3 4).freeze
+    private_constant :SCALES
+
     def srcset
-      (1..4).map { |scale| "#{url(scale)} #{scale}x" }.join(", ")
+      SCALES.map { |scale| "#{url(scale.to_i)} #{scale}x" }.join(", ")
     end
 
     # See http://primercss.io/avatars/#small-avatars


### PR DESCRIPTION
In comparison to converting an integer to string, converting *number-like* strings to an integer is more economical memory-allocation-wise because Ruby integers are *fixed entities*.

In other words, while `3.to_s.object_id` **will always be different**, `"3".to_i.object_id` **will always be the same**.