### PR TITLE
Reduce allocations from computing username

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -53,8 +53,12 @@ module Jekyll
       matches = @text.match(%r!\buser=([\w\.]+)\b!)
       if matches
         lookup_variable(@context, matches[1])
+      elsif @text.include?(" ")
+        result = @text.split(" ")[0]
+        result.sub!("@", "")
+        result
       else
-        @text.split(" ").first.sub("@", "")
+        @text
       end
     end
 


### PR DESCRIPTION
## Summary
- `string.split(str)` generates an Array even if `string` doesn't contain `str`. Therefore, to avoid allocating an intermediate array unnecessarily, `split` given `string` only if `string` contains `str`.
- `string.sub(str, ...)` duplicates `string` even if `string` doesn't contain `str`. Therefore, opt to use `string.sub!(str, ...)` instead.