### PR TITLE
Use `Kernel#format` to render `<img />` HTML tag

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -27,8 +27,6 @@ module Jekyll
 
     private_constant :BASE_ATTRIBUTES, :BASE_TEMPLATE, :LAZY_TEMPLATE
 
-    #
-
     def initialize(_tag_name, text, _tokens)
       super
       @text = text

--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -6,9 +6,28 @@ module Jekyll
   class Avatar < Liquid::Tag
     include Jekyll::LiquidExtensions
 
+    def self.generate_template_with(keys)
+      attrs = (BASE_ATTRIBUTES + keys).map! { |key| %(#{key}="%<#{key}>s") }.join(" ")
+      "<img #{attrs} />"
+    end
+    private_class_method :generate_template_with
+
+    #
+
     SERVERS      = 4
     DEFAULT_SIZE = 40
     API_VERSION  = 3
+
+    BASE_ATTRIBUTES = %w(
+      class alt width height data-proofer-ignore src
+    ).freeze
+
+    BASE_TEMPLATE = generate_template_with %w(srcset)
+    LAZY_TEMPLATE = generate_template_with %w(data-src data-srcset)
+
+    private_constant :BASE_ATTRIBUTES, :BASE_TEMPLATE, :LAZY_TEMPLATE
+
+    #
 
     def initialize(_tag_name, text, _tokens)
       super
@@ -19,28 +38,28 @@ module Jekyll
     def render(context)
       @context = context
       @text    = @markup.render(@context)
-      attrs    = attributes.map { |k, v| "#{k}=\"#{v}\"" }.join(" ")
-      "<img #{attrs} />"
+      template = lazy_load? ? LAZY_TEMPLATE : BASE_TEMPLATE
+      format(template, attributes)
     end
 
     private
 
     def attributes
       result = {
-        "class"               => classes,
-        "alt"                 => username,
-        "width"               => size,
-        "height"              => size,
-        "data-proofer-ignore" => true
+        :class                 => classes,
+        :alt                   => username,
+        :width                 => size,
+        :height                => size,
+        :"data-proofer-ignore" => true
       }
 
       if lazy_load?
-        result["src"] = ""
-        result["data-src"] = url
-        result["data-srcset"] = srcset
+        result[:src] = ""
+        result[:"data-src"] = url
+        result[:"data-srcset"] = srcset
       else
-        result["src"] = url
-        result["srcset"] = srcset
+        result[:src] = url
+        result[:srcset] = srcset
       end
 
       result

--- a/spec/jekyll/avatar_spec.rb
+++ b/spec/jekyll/avatar_spec.rb
@@ -109,13 +109,13 @@ describe Jekyll::Avatar do
   it "builds the params" do
     attrs = subject.send(:attributes)
     expect(attrs).to eql({
-      "data-proofer-ignore" => true,
-      "class"               => "avatar avatar-small",
-      "alt"                 => username,
-      "src"                 => src,
-      "srcset"              => srcset,
-      "width"               => width,
-      "height"              => height
+      :"data-proofer-ignore" => true,
+      :class                 => "avatar avatar-small",
+      :alt                   => username,
+      :src                   => src,
+      :srcset                => srcset,
+      :width                 => width,
+      :height                => height
     })
   end
 


### PR DESCRIPTION
This change is to avoid converting the `:attributes` Hash into an Array and then into a String on every call to the `:render` method.

To facilitate this, the keys of the `:attribute` Hash are now Symbols.