### PR TITLE
Assign string values for attributes

### DIFF
--- a/lib/jekyll-avatar.rb
+++ b/lib/jekyll-avatar.rb
@@ -15,8 +15,8 @@ module Jekyll
     #
 
     SERVERS      = 4
-    DEFAULT_SIZE = 40
-    API_VERSION  = 3
+    DEFAULT_SIZE = "40"
+    API_VERSION  = "3"
 
     BASE_ATTRIBUTES = %w(
       class alt width height data-proofer-ignore src
@@ -48,7 +48,7 @@ module Jekyll
         :alt                   => username,
         :width                 => size,
         :height                => size,
-        :"data-proofer-ignore" => true
+        :"data-proofer-ignore" => "true"
       }
 
       if lazy_load?
@@ -80,13 +80,14 @@ module Jekyll
       end
     end
 
+    # Returns a string value
     def size
       matches = @text.match(%r!\bsize=(\d+)\b!i)
-      matches ? matches[1].to_i : DEFAULT_SIZE
+      matches ? matches[1] : DEFAULT_SIZE
     end
 
     def path(scale = 1)
-      "#{username}?v=#{API_VERSION}&s=#{size * scale}"
+      "#{username}?v=#{API_VERSION}&s=#{scale == 1 ? size : (size.to_i * scale)}"
     end
 
     def server_number
@@ -122,7 +123,7 @@ module Jekyll
 
     # See http://primercss.io/avatars/#small-avatars
     def classes
-      size < 48 ? "avatar avatar-small" : "avatar"
+      size.to_i < 48 ? "avatar avatar-small" : "avatar"
     end
   end
 end

--- a/spec/jekyll/avatar_spec.rb
+++ b/spec/jekyll/avatar_spec.rb
@@ -24,13 +24,13 @@ describe Jekyll::Avatar do
     uri.query_values = { :v => 3, :s => width }.to_a
     uri
   end
-  let(:height) { 40 }
-  let(:width) { 40 }
+  let(:height) { "40" }
+  let(:width) { "40" }
   let(:scales) { (1..4) }
   let(:src) { src_hash["1x"] }
   let(:src_hash) do
     scales.map do |scale|
-      uri.query_values = { "v" => 3, "s" => width * scale }.to_a
+      uri.query_values = { "v" => 3, "s" => width.to_i * scale }.to_a
       ["#{scale}x", uri.to_s]
     end.to_h
   end
@@ -109,7 +109,7 @@ describe Jekyll::Avatar do
   it "builds the params" do
     attrs = subject.send(:attributes)
     expect(attrs).to eql({
-      :"data-proofer-ignore" => true,
+      :"data-proofer-ignore" => "true",
       :class                 => "avatar avatar-small",
       :alt                   => username,
       :src                   => src,
@@ -131,7 +131,7 @@ describe Jekyll::Avatar do
     end
 
     context "when given a scale" do
-      let(:width) { 80 }
+      let(:width) { "80" }
 
       it "builds the URL with a scale" do
         expect(subject.send(:url, 2)).to eql(src)
@@ -156,7 +156,7 @@ describe Jekyll::Avatar do
   end
 
   context "with a size is passed" do
-    let(:width) { 45 }
+    let(:width) { "45" }
     let(:args) { "size=#{width}" }
 
     it "parses the user's requested size" do
@@ -175,7 +175,7 @@ describe Jekyll::Avatar do
   end
 
   context "with a size > 48" do
-    let(:width) { 80 }
+    let(:width) { "80" }
     let(:args) { "size=#{width}" }
 
     it "doesn't include the avatar-small class" do


### PR DESCRIPTION
Instead of interpolating an integer `size` into a string for each `<img />` rendered which involves allocation of the string value on each render, (when `size == 24`, then "#{size}" leads to allocation of `"24"`), it would be more optimal if `size` were a String value to begin with and only converted into its Integer counterpart when necessary.

Similarly, `API_VERSION` is now a String value and `:"data-proofer-ignore"` always `"true"`