### PR TITLE
Remove redundant specifications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,24 +2,13 @@ inherit_from: .rubocop_todo.yml
 
 require: 
   - rubocop-jekyll
-  - rubocop-performance
   - rubocop-rspec
-  
+
 inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
-Naming/FileName:
-  Enabled: false
-
-Metrics/LineLength:
-  Exclude:
-    - spec/*/**
-
-Metrics/BlockLength:
-  Enabled: false
-
 AllCops:
+  NewCops: enable
   Exclude:
     - script/**/*
     - vendor/**/*
-  NewCops: enable

--- a/jekyll-avatar.gemspec
+++ b/jekyll-avatar.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.9"
-  spec.add_development_dependency "rubocop-jekyll", "~> 0.10"
-  spec.add_development_dependency "rubocop-performance", "~> 1.5"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.12"
   spec.add_development_dependency "rubocop-rspec", "~> 2.0"
 end


### PR DESCRIPTION
  * `rubocop-jekyll` already loads `rubocop-performance` extension
  * `Naming/FileName` is already disabled via `rubocop-jekyll`
  * `Metrics/BlockLength` is already disabled for spec files via `rubocop-jekyll`
  * `Metrics/LineLength` has been renamed to `Layout/LineLength` in recent RuboCop versions

---

Ideally, I'd recommend locking `rubocop-jekyll` to the patch version (`'~> 0.12.0"`) to avoid dealing with offenses from future cops unexpectedly. But since you made a conscious decision to keep it open, I'll not push for it.